### PR TITLE
Fix tiling to scale bounding boxes based on actual tile dimensions

### DIFF
--- a/src/preprocessing/Tiling_images_to_yolo.py
+++ b/src/preprocessing/Tiling_images_to_yolo.py
@@ -210,7 +210,7 @@ class XViewTiler:
                                 bbox[2] - x_start,
                                 bbox[3] - y_start
                             ]
-                            tile_bboxes.append(self.convert_bbox_to_yolo_format(adjusted_bbox, self.tile_size, self.tile_size))
+                            tile_bboxes.append(self.convert_bbox_to_yolo_format(adjusted_bbox, tile_width, tile_height))
                             tile_classes.append(cls_id)
 
                     if tile_bboxes:


### PR DESCRIPTION
Fix tiling to scale based on actual tile dimensions instead of target tile size when converting bounding boxes to relative format.

Should fix these scaling issues:

![image](https://github.com/user-attachments/assets/775d1646-9a17-47e2-8f03-f0d8721bd346)
![image](https://github.com/user-attachments/assets/474f9305-5b17-483a-b6cb-82d8028d61d0)
